### PR TITLE
fix: add missing matcher for email api

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,6 @@ export { middleware } from 'nextra/locales'
 export const config = {
   // Matcher ignoring `/_next/` and `/api/`
   matcher: [
-    '/((?!api/mdx|api/patterns/random|api/og|_next/static|_next/image|favicon.ico|robots.txt|og/opengraph-image.png|twitter-image|sitemap.xml|6ba7b811-9dad-11d1-80b4.txt|apple-icon.png|manifest|_pagefind).*)'
+    '/((?!api/mdx|api/email|api/patterns/random|api/og|_next/static|_next/image|favicon.ico|robots.txt|og/opengraph-image.png|twitter-image|sitemap.xml|6ba7b811-9dad-11d1-80b4.txt|apple-icon.png|manifest|_pagefind).*)'
   ]
 }


### PR DESCRIPTION
Change to the `middleware.ts` file to update the matcher configuration to allow people newsletter subscription.

Fixes #27 