### PR TITLE
fix: use production URL for llms.txt and llms-full.txt

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -6,6 +6,7 @@ import { NextResponse } from 'next/server';
 import { remark } from 'remark';
 import remarkGfm from 'remark-gfm';
 import remarkStringify from 'remark-stringify';
+import { BASE_URL } from '../_constants/project';
 
 export const dynamic = 'force-dynamic';
 
@@ -86,10 +87,7 @@ async function processFile(file: string, options: ProcessFileOptions) {
         .join(' ');
 
     const processed = await processContent(content);
-    const patternUrl = new URL(
-      `/patterns/${category}/${basename}`,
-      options.baseUrl
-    ).toString();
+    const patternUrl = new URL(`/patterns/${category}/${basename}`, options.baseUrl).toString();
 
     return `# ${category.toUpperCase()}: [${title}](${patternUrl})
 
@@ -105,15 +103,7 @@ ${processed}`;
 export async function GET(_request: Request) {
   try {
     // Get base URL
-    const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
-      ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-      : process.env.NODE_ENV === 'development'
-        ? 'http://localhost:3060'
-        : '';
-
-    if (!baseUrl) {
-      return NextResponse.json({ error: 'Base URL not configured' }, { status: 500 });
-    }
+    const baseUrl = process.env.NODE_ENV === 'development' ? 'http://localhost:3060' : BASE_URL;
 
     // Get files and process them
     const files = await fg(['content/patterns/**/*.mdx']);

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
 import { NextResponse } from 'next/server';
+import { BASE_URL } from '../_constants/project';
 
 const contentDirectory = path.join(process.cwd(), 'content/patterns');
 
@@ -58,9 +59,7 @@ export async function GET(_request: Request) {
     const patterns = getAllPatterns();
 
     // Get base URL
-    const baseUrl = process.env.NODE_ENV === 'development'
-      ? 'http://localhost:3060'
-      : `https://${process.env.NEXT_PUBLIC_VERCEL_URL || 'localhost:3060'}`;
+    const baseUrl = process.env.NODE_ENV === 'development' ? 'http://localhost:3060' : BASE_URL;
 
     // Generate the text content
     let content = `# UX Patterns for Developers


### PR DESCRIPTION
- Replace NEXT_PUBLIC_VERCEL_URL with BASE_URL constant
- Ensures llms.txt uses uxpatterns.dev instead of preview URLs
- Fixes issue #95 with incorrect domain in generated files

fixes #95 