### PR TITLE
feat: adjust homepage grid layout from 5 to 4 cards per row

### DIFF
--- a/app/_components/sections/overview-grid.tsx
+++ b/app/_components/sections/overview-grid.tsx
@@ -20,7 +20,7 @@ export const OverviewGrid = async ({ lang }: { lang: string }) => {
             <h2 className="text-2xl font-bold text-foreground">{category.name}</h2>
             <p className="mt-2 text-muted-foreground text-sm">{category.description}</p>
           </div>
-          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4">
             {category.patterns.map((pattern) => (
               <PatternWrapper key={pattern.title} pattern={pattern} />
             ))}


### PR DESCRIPTION
Reduces grid density to improve visual breathing room and readability. Each pattern card is now more prominent and easier to scan.

Responsive breakpoints remain unchanged:
- Mobile: 1 column
- Small: 2 columns
- Medium: 3 columns
- Large/XL: 4 columns (previously 5 on XL)