### PR TITLE
perf(web): let content page regens finish instead of 504-looping

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -26,6 +26,22 @@
 		"app/api/newsletter/route.ts": {
 			"memory": 256,
 			"maxDuration": 10
+		},
+		"app/[...slug]/page.tsx": {
+			"memory": 3008,
+			"maxDuration": 60
+		},
+		"app/blog/[slug]/page.tsx": {
+			"memory": 3008,
+			"maxDuration": 60
+		},
+		"app/blog/page.tsx": {
+			"memory": 1024,
+			"maxDuration": 30
+		},
+		"app/pages/[pageName]/page.tsx": {
+			"memory": 1769,
+			"maxDuration": 30
 		}
 	},
 	"rewrites": [


### PR DESCRIPTION
## Problem
Cold ISR regenerations of MDX pages (glossary/patterns/pattern-guide) exceed the 15s function ceiling and 504. A timed-out regen writes nothing to cache, so the next request re-runs the same cold render and times out again — an **unbounded loop of 15s renders that never caches**. This is the core driver of the deploy-day GB-Hrs spikes (verified post-#256: `GET /glossary/p/pagination 504 cache=MISS`).

## Fix
Give the MDX-rendering page functions max CPU + duration headroom in `vercel.json` so the regen **completes** and populates the cache:
- `app/[...slug]/page.tsx`, `app/blog/[slug]/page.tsx`: `memory 3008` (~2× CPU), `maxDuration 60`
- `app/blog/page.tsx`: `memory 1024`, `maxDuration 30`
- `app/pages/[pageName]/page.tsx`: `memory 1769`, `maxDuration 30`

After the first successful regen the page serves as static HTML (no function), so the higher memory is only paid on rare post-deploy/weekly regenerations — net GB-Hrs drop because the retry loop is broken.

## Follow-up (not in this PR)
- Eliminate runtime MDX compilation entirely (render velite-precompiled body) — bigger change, 6 `pattern-guide` files depend on runtime mdxScope.
- OpenPanel `/api/stats` returns 401 "Client is not allowed to export" — enable Export on the OpenPanel client (dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated route-specific runtime settings for several web pages, including memory and execution time limits, to improve reliability for high-load pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->