### PR TITLE
fix(web): narrow MCP host blocking to scanners only

### DIFF
--- a/apps/web/lib/bot-detection.ts
+++ b/apps/web/lib/bot-detection.ts
@@ -10,6 +10,12 @@ const GOOD_BOTS =
 const BAD_BOTS =
 	/DotBot|MJ12bot|BlexBot|AhrefsBot|SemrushBot|GPTBot|ClaudeBot|anthropic-ai|CCBot|HeadlessChrome|PhantomJS|Puppeteer|sqlmap|nikto|masscan|Bytespider|PetalBot|Scrapy|HTTrack|wget\/|curl\/|python-requests/i;
 
+// Malicious vulnerability/port scanners only. Used for API surfaces (e.g. the
+// MCP endpoint) that are *meant* to be hit by programmatic clients, so we must
+// NOT block generic HTTP libraries (curl, wget, python-requests) there —
+// rate limiting handles abuse. We still hard-block actual attack tooling.
+const SCANNER_UA = /sqlmap|nikto|masscan|nmap|nuclei|wpscan|zgrab|dirbuster/i;
+
 // Paths commonly probed by vulnerability scanners
 const SUSPICIOUS_PATHS =
 	/^\/(wp-admin|wp-login|wp-content|wp-includes|\.env|\.git|phpmyadmin|phpinfo|administrator|cgi-bin|\.aws)/i;
@@ -71,6 +77,15 @@ export function detectBot(
 	}
 
 	return { isBot: false, botType: "human", botName: null };
+}
+
+/**
+ * True only for known malicious scanners/attack tooling. Safe to block on
+ * programmatic API surfaces (e.g. MCP) without locking out legitimate clients.
+ */
+export function isVulnerabilityScanner(userAgent: string | null): boolean {
+	if (!userAgent) return false;
+	return SCANNER_UA.test(userAgent);
 }
 
 export function getClientIP(request: NextRequest): string | null {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,7 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
-import { detectBot, getClientIP, getRouteCategory } from "@/lib/bot-detection";
+import {
+	detectBot,
+	getClientIP,
+	getRouteCategory,
+	isVulnerabilityScanner,
+} from "@/lib/bot-detection";
 import { checkRateLimit, getRateLimitStore } from "@/lib/rate-limit-store";
 
 const MCP_HOST = "mcp.uxpatterns.dev";
@@ -20,9 +25,11 @@ export async function proxy(request: NextRequest) {
 	// MCP host maps entirely to the /api/mcp function. Protect it at the edge
 	// BEFORE rewriting, otherwise the function takes every hit unthrottled.
 	if (host === MCP_HOST) {
-		// Block known-bad scrapers, but not empty/odd UAs: legit MCP HTTP
-		// clients frequently send no recognizable User-Agent.
-		if (detectBot(userAgent, pathname).botType === "bad") {
+		// Only hard-block malicious scanners here. MCP is a programmatic API hit
+		// by generic HTTP clients (curl, python-requests, custom agents), so the
+		// general bad-bot list would lock out legitimate callers. Per-IP rate
+		// limiting below is what actually contains abuse.
+		if (isVulnerabilityScanner(userAgent)) {
 			return new Response("Forbidden", { status: 403 });
 		}
 


### PR DESCRIPTION
## Why
PR #256 added bad-bot blocking on `mcp.uxpatterns.dev`, but it reused the general bad-bot list which matches generic HTTP clients (`curl/`, `wget/`, `python-requests`, `Scrapy`) — exactly what legitimate MCP callers use. That would 403 real programmatic clients.

## Fix
- Add `isVulnerabilityScanner()` (matches `sqlmap|nikto|masscan|nmap|nuclei|wpscan|zgrab|dirbuster`) to `bot-detection.ts`.
- On the MCP host, hard-block only those scanners; rely on the existing per-IP rate limit (30/window) to contain abuse from everything else.
- Main-site (non-MCP) traffic still uses the full bad-bot list unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)